### PR TITLE
DactylManuform: Change default mouse config

### DIFF
--- a/keyboards/handwired/dactyl_manuform/config.h
+++ b/keyboards/handwired/dactyl_manuform/config.h
@@ -45,6 +45,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* number of backlight levels */
 // #define BACKLIGHT_LEVELS 3
 
+/* mouse config */
+#define MOUSEKEY_INTERVAL       20
+#define MOUSEKEY_DELAY          0
+#define MOUSEKEY_TIME_TO_MAX    60
+#define MOUSEKEY_MAX_SPEED      7
+#define MOUSEKEY_WHEEL_DELAY 0
+
 /* Set 0 if debouncing isn't needed */
 #define DEBOUNCING_DELAY 5
 


### PR DESCRIPTION
The default mouse config parameters are slow and not very user friendly, this commit overrides the default
values.
wq
Signed-off-by: Sameeh Jubran <sameeh.j@gmail.com>